### PR TITLE
include concept name in header

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,11 +70,12 @@ module.exports = function (ctx, cb) {
       return send(`Unable to find the "${conceptName}" concept, sorry.`);
     }
 
+    const conceptTypeName = concept['name-singular'];
     const respText = conceptValue.details[0].description;
     const spec = conceptValue.details[0].documentation;
     const site = conceptValue.id;
     send(
-        `*${conceptName}*:\n${respText}`,
+        `*${conceptTypeName} ${conceptName}*:\n${respText}`,
         [
           {
             title: "See the detailed specification",


### PR DESCRIPTION
Instead of just returning the name, the response will also include the concept class singular.

For example instead of simply `*202*` it will say `*HTTP Status Code 202*`.